### PR TITLE
Fix: expose env to browser

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  transpilePackages: ['@graphql-tools/load'],
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  transpilePackages: ['@graphql-tools/load'],
 }
 
 module.exports = nextConfig

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,11 +2,12 @@ import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
 import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client'
 
-const apiBaseURI =
-  process.env.NEXT_PUBLIC_VERCEL_URL || 'http://localhost:3000/'
+const apiBaseURI = process.env.NEXT_PUBLIC_VERCEL_URL
+  ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
+  : 'http://localhost:3000'
 
 const client = new ApolloClient({
-  uri: new URL('/api/graphql', apiBaseURI).href,
+  uri: new URL('/api/graphql', apiBaseURI).toString(),
   cache: new InMemoryCache(),
 })
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,7 +2,8 @@ import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
 import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client'
 
-const apiBaseURI = process.env.VERCEL_URL || 'http://localhost:3000/'
+const apiBaseURI =
+  process.env.NEXT_PUBLIC_VERCEL_URL || 'http://localhost:3000/'
 
 const client = new ApolloClient({
   uri: apiBaseURI + 'api/graphql',

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,7 +6,7 @@ const apiBaseURI =
   process.env.NEXT_PUBLIC_VERCEL_URL || 'http://localhost:3000/'
 
 const client = new ApolloClient({
-  uri: apiBaseURI + 'api/graphql',
+  uri: new URL('/api/graphql', apiBaseURI).href,
   cache: new InMemoryCache(),
 })
 

--- a/pages/api/graphql/index.ts
+++ b/pages/api/graphql/index.ts
@@ -1,18 +1,23 @@
 import { ApolloServer } from '@apollo/server'
 import { startServerAndCreateNextHandler } from '@as-integrations/next'
-import { loadSchemaSync } from '@graphql-tools/load'
+import { loadSchema } from '@graphql-tools/load'
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader'
 import { resolvers } from './resolver'
 
-const typeDefs = loadSchemaSync('pages/api/graphql/schema/root.graphql', {
-  loaders: [new GraphQLFileLoader()],
-})
+const main = async () => {
+  const typeDefs = await loadSchema('pages/api/graphql/schema/root.graphql', {
+    loaders: [new GraphQLFileLoader()],
+  })
 
-const server = new ApolloServer({
-  typeDefs,
-  resolvers,
-})
+  const server = new ApolloServer({
+    typeDefs,
+    resolvers,
+  })
+  //TODO: GraphQLResolveInfo does not match BaseContext
+  // @ts-expect-error to be fixed
+  return startServerAndCreateNextHandler(server)
+}
 
-//TODO: GraphQLResolveInfo does not match BaseContext
-// @ts-expect-error to be fixed
-export default startServerAndCreateNextHandler(server)
+const handler = main()
+
+export default handler


### PR DESCRIPTION
expose graphql server uri to browser

because NextJS env variables is not exposed to browser in default.