### PR TITLE
Feat: define task model for prisma & GraphQL

### DIFF
--- a/.vscode/setting.json
+++ b/.vscode/setting.json
@@ -1,0 +1,9 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "editor.formatOnSave": true,
+  "[prisma]": {
+    "editor.defaultFormatter": "Prisma.prisma"
+  }
+}

--- a/codegen.ts
+++ b/codegen.ts
@@ -14,6 +14,9 @@ const config: CodegenConfig = {
         mappers: {
           PrismaUser: '@prisma/client/index.d#User',
         },
+        scalars: {
+          Date: 'string',
+        },
       },
     },
   },

--- a/codegen.ts
+++ b/codegen.ts
@@ -15,7 +15,7 @@ const config: CodegenConfig = {
           PrismaUser: '@prisma/client/index.d#User',
         },
         scalars: {
-          Date: 'string',
+          Date: 'Date',
         },
       },
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "gen": "prisma generate",
+    "migrate": "prisma migrate dev",
+    "studio": "prisma studio",
+    "gqlgen": "graphql-codegen --config codegen.ts"
   },
   "dependencies": {
     "@apollo/client": "^3.7.10",

--- a/pages/api/graphql/index.ts
+++ b/pages/api/graphql/index.ts
@@ -19,22 +19,22 @@ input NewUser {
 
 type Task {
   id: ID!
-  userId: String
-  name: String!
+  userId: String!
+  title: String!
   content: String
   done: Boolean!
-  due: String
-  start: String
-  end: String
+  due: Date
+  start: Date
+  end: Date
   group: String
   type: String
-  priority: String
+  priority: Int
   archived: Boolean!
 }
 
 input NewTask {
   userId: String!
-  name: String!
+  title: String!
   content: String
 }
 

--- a/pages/api/graphql/index.ts
+++ b/pages/api/graphql/index.ts
@@ -1,9 +1,11 @@
 import { ApolloServer } from '@apollo/server'
 import { startServerAndCreateNextHandler } from '@as-integrations/next'
 import { resolvers } from './resolver'
+import dateScalar from './resolver/dateScalar'
 
-//TODO: User id is string & add models for nextauth
 const typeDefs = `#graphql
+scalar Date
+
 type PrismaUser {
   id: ID!
   name: String
@@ -14,9 +16,10 @@ input NewUser {
   name: String
   email: String!
 }
+
 type Task {
   id: ID!
-  userId: Int
+  userId: String
   name: String!
   content: String
   done: Boolean!
@@ -37,8 +40,8 @@ input NewTask {
 
 type Query {
   user(id: String!): PrismaUser
-  tasks(userId: Int!): [Task!]!
-  task(id: Int!): Task!
+  tasks(userId: String!): [Task!]!
+  task(id: String!): Task!
 }
 
 type Mutation {
@@ -49,7 +52,10 @@ type Mutation {
 
 const server = new ApolloServer({
   typeDefs,
-  resolvers,
+  resolvers: {
+    Date: dateScalar,
+    ...resolvers,
+  },
 })
 
 //TODO: GraphQLResolveInfo does not match BaseContext

--- a/pages/api/graphql/index.ts
+++ b/pages/api/graphql/index.ts
@@ -33,15 +33,15 @@ type Task {
 }
 
 input NewTask {
+  userId: String!
   name: String!
   content: String
-  userId: Int!
 }
 
 type Query {
   user(id: String!): PrismaUser
   tasks(userId: String!): [Task!]!
-  task(id: String!): Task!
+  task(id: String!): Task
 }
 
 type Mutation {

--- a/pages/api/graphql/resolver/dateScalar.ts
+++ b/pages/api/graphql/resolver/dateScalar.ts
@@ -1,0 +1,28 @@
+import { GraphQLScalarType, Kind } from 'graphql'
+
+const dateScalar = new GraphQLScalarType({
+  name: 'Date',
+  description: 'Date custom scalar type',
+  serialize(value) {
+    if (value instanceof Date) {
+      return value.getTime() // Convert outgoing Date to integer for JSON
+    }
+    throw Error('GraphQL Date Scalar serializer expected a `Date` object')
+  },
+  parseValue(value) {
+    if (typeof value === 'number') {
+      return new Date(value) // Convert incoming integer to Date
+    }
+    throw new Error('GraphQL Date Scalar parser expected a `number`')
+  },
+  parseLiteral(ast) {
+    if (ast.kind === Kind.INT) {
+      // Convert hard-coded AST string to integer and then to Date
+      return new Date(parseInt(ast.value, 10))
+    }
+    // Invalid hard-coded value (not an integer)
+    return null
+  },
+})
+
+export default dateScalar

--- a/pages/api/graphql/resolver/index.ts
+++ b/pages/api/graphql/resolver/index.ts
@@ -13,6 +13,7 @@ export const resolvers: Resolvers = {
       })
       return result
     },
+    // TODO: Fix ts error, or maybe issue? ref: https://github.com/dotansimha/graphql-code-generator/issues/3174
     task: async (_, args) => {
       const result = await prisma.task.findUnique({
         where: {

--- a/pages/api/graphql/resolver/index.ts
+++ b/pages/api/graphql/resolver/index.ts
@@ -13,6 +13,14 @@ export const resolvers: Resolvers = {
       })
       return result
     },
+    task: async (_, args) => {
+      const result = await prisma.task.findUnique({
+        where: {
+          id: String(args.id),
+        },
+      })
+      return result
+    },
   },
   Mutation: {
     createUser: async (_, args) => {

--- a/pages/api/graphql/resolver/index.ts
+++ b/pages/api/graphql/resolver/index.ts
@@ -34,5 +34,18 @@ export const resolvers: Resolvers = {
       })
       return result
     },
+    createTask: async (_, args) => {
+      const { userId, title, content } = args.input
+      const result = await prisma.task.create({
+        data: {
+          userId,
+          title,
+          content,
+          done: false,
+          archived: false,
+        },
+      })
+      return result
+    },
   },
 }

--- a/pages/api/graphql/schema/root.graphql
+++ b/pages/api/graphql/schema/root.graphql
@@ -4,7 +4,7 @@
 type Query {
   user(id: String!): PrismaUser
   tasks(userId: Int!): [Task!]!
-  task(id: Int!): Task!
+  task(id: String!): Task
 }
 
 type Mutation {

--- a/pages/api/graphql/schema/root.graphql
+++ b/pages/api/graphql/schema/root.graphql
@@ -3,7 +3,7 @@
 
 type Query {
   user(id: String!): PrismaUser
-  tasks(userId: Int!): [Task!]!
+  tasks(userId: String!): [Task!]!
   task(id: String!): Task
 }
 

--- a/pages/api/graphql/schema/scalar.graphql
+++ b/pages/api/graphql/schema/scalar.graphql
@@ -1,0 +1,1 @@
+scalar Date

--- a/pages/api/graphql/schema/task.graphql
+++ b/pages/api/graphql/schema/task.graphql
@@ -1,20 +1,22 @@
+#import Date from "scalar.graphql"
+
 type Task {
   id: ID!
-  userId: Int
-  name: String!
+  userId: String!
+  title: String!
   content: String
   done: Boolean!
-  due: String
-  start: String
-  end: String
+  due: Date
+  start: Date
+  end: Date
   group: String
   type: String
-  priority: String
+  priority: Int
   archived: Boolean!
 }
 
 input NewTask {
-  name: String!
+  userId: String!
+  title: String!
   content: String
-  userId: Int!
 }

--- a/pages/api/graphql/types/graphql.ts
+++ b/pages/api/graphql/types/graphql.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { GraphQLResolveInfo } from 'graphql';
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 import { User } from '@prisma/client/index.d';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
@@ -14,6 +14,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  Date: string;
 };
 
 export type Mutation = {
@@ -34,8 +35,8 @@ export type MutationCreateUserArgs = {
 
 export type NewTask = {
   content?: InputMaybe<Scalars['String']>;
-  name: Scalars['String'];
-  userId: Scalars['Int'];
+  title: Scalars['String'];
+  userId: Scalars['String'];
 };
 
 export type NewUser = {
@@ -52,14 +53,14 @@ export type PrismaUser = {
 
 export type Query = {
   __typename?: 'Query';
-  task: Task;
+  task?: Maybe<Task>;
   tasks: Array<Task>;
   user?: Maybe<PrismaUser>;
 };
 
 
 export type QueryTaskArgs = {
-  id: Scalars['Int'];
+  id: Scalars['String'];
 };
 
 
@@ -77,15 +78,15 @@ export type Task = {
   archived: Scalars['Boolean'];
   content?: Maybe<Scalars['String']>;
   done: Scalars['Boolean'];
-  due?: Maybe<Scalars['String']>;
-  end?: Maybe<Scalars['String']>;
+  due?: Maybe<Scalars['Date']>;
+  end?: Maybe<Scalars['Date']>;
   group?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
-  name: Scalars['String'];
-  priority?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['String']>;
+  priority?: Maybe<Scalars['Int']>;
+  start?: Maybe<Scalars['Date']>;
+  title: Scalars['String'];
   type?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['Int']>;
+  userId: Scalars['String'];
 };
 
 
@@ -159,6 +160,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+  Date: ResolverTypeWrapper<Scalars['Date']>;
   ID: ResolverTypeWrapper<Scalars['ID']>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
   Mutation: ResolverTypeWrapper<{}>;
@@ -173,6 +175,7 @@ export type ResolversTypes = {
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = {
   Boolean: Scalars['Boolean'];
+  Date: Scalars['Date'];
   ID: Scalars['ID'];
   Int: Scalars['Int'];
   Mutation: {};
@@ -183,6 +186,10 @@ export type ResolversParentTypes = {
   String: Scalars['String'];
   Task: Task;
 };
+
+export interface DateScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Date'], any> {
+  name: 'Date';
+}
 
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   createTask?: Resolver<ResolversTypes['Task'], ParentType, ContextType, RequireFields<MutationCreateTaskArgs, 'input'>>;
@@ -197,7 +204,7 @@ export type PrismaUserResolvers<ContextType = any, ParentType extends ResolversP
 };
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  task?: Resolver<ResolversTypes['Task'], ParentType, ContextType, RequireFields<QueryTaskArgs, 'id'>>;
+  task?: Resolver<Maybe<ResolversTypes['Task']>, ParentType, ContextType, RequireFields<QueryTaskArgs, 'id'>>;
   tasks?: Resolver<Array<ResolversTypes['Task']>, ParentType, ContextType, RequireFields<QueryTasksArgs, 'userId'>>;
   user?: Resolver<Maybe<ResolversTypes['PrismaUser']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'id'>>;
 };
@@ -206,19 +213,20 @@ export type TaskResolvers<ContextType = any, ParentType extends ResolversParentT
   archived?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   content?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   done?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  due?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  end?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  due?: Resolver<Maybe<ResolversTypes['Date']>, ParentType, ContextType>;
+  end?: Resolver<Maybe<ResolversTypes['Date']>, ParentType, ContextType>;
   group?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  priority?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  start?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  priority?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  start?: Resolver<Maybe<ResolversTypes['Date']>, ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  userId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  userId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type Resolvers<ContextType = any> = {
+  Date?: GraphQLScalarType;
   Mutation?: MutationResolvers<ContextType>;
   PrismaUser?: PrismaUserResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;

--- a/pages/api/graphql/types/graphql.ts
+++ b/pages/api/graphql/types/graphql.ts
@@ -65,7 +65,7 @@ export type QueryTaskArgs = {
 
 
 export type QueryTasksArgs = {
-  userId: Scalars['Int'];
+  userId: Scalars['String'];
 };
 
 

--- a/pages/api/graphql/types/graphql.ts
+++ b/pages/api/graphql/types/graphql.ts
@@ -14,7 +14,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  Date: string;
+  Date: Date;
 };
 
 export type Mutation = {

--- a/prisma/migrations/20230401070703_task/migration.sql
+++ b/prisma/migrations/20230401070703_task/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - The primary key for the `Task` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - Added the required column `archived` to the `Task` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `done` to the `Task` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `userId` to the `Task` table without a default value. This is not possible if the table is not empty.
+  - Made the column `title` on table `Task` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Task" DROP CONSTRAINT "Task_pkey",
+ADD COLUMN     "archived" BOOLEAN NOT NULL,
+ADD COLUMN     "done" BOOLEAN NOT NULL,
+ADD COLUMN     "due" TIMESTAMP(3),
+ADD COLUMN     "end" TIMESTAMP(3),
+ADD COLUMN     "group" TEXT,
+ADD COLUMN     "priority" INTEGER,
+ADD COLUMN     "start" TIMESTAMP(3),
+ADD COLUMN     "type" TEXT,
+ADD COLUMN     "userId" TEXT NOT NULL,
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ALTER COLUMN "title" SET NOT NULL,
+ADD CONSTRAINT "Task_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "Task_id_seq";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,24 +18,33 @@ model User {
 }
 
 model Task {
-  id           Int      @id @default(autoincrement())
-  title        String?
-  content      String?
+  id       String    @id @default(cuid())
+  userId   String
+  title    String
+  content  String?
+  done     Boolean
+  due      DateTime?
+  start    DateTime?
+  end      DateTime?
+  group    String?
+  type     String?
+  priority Int?
+  archived Boolean
 }
 
 model Account {
-  id                 String  @id @default(cuid())
-  userId             String
-  type               String
-  provider           String
-  providerAccountId  String
-  refresh_token      String?  @db.Text
-  access_token       String?  @db.Text
-  expires_at         Int?
-  token_type         String?
-  scope              String?
-  id_token           String?  @db.Text
-  session_state      String?
+  id                String  @id @default(cuid())
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String? @db.Text
+  access_token      String? @db.Text
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String? @db.Text
+  session_state     String?
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
# Feat
- add task model to Prisma
- add task model to GraphQL
- define custom scalar "Date" in GraphQL
- generate type definition of Date scalar with graphql-codegen
