### PR TITLE
Refactor: instatiate a single prisma client

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,7 +1,6 @@
-import { PrismaClient } from '@prisma/client'
 import { defineConfig } from 'cypress'
 
-const prisma = new PrismaClient()
+import { prisma } from '@/prisma/client'
 
 export default defineConfig({
   e2e: {

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,9 +1,8 @@
 import { PrismaAdapter } from '@next-auth/prisma-adapter'
-import { PrismaClient } from '@prisma/client'
 import NextAuth, { NextAuthOptions } from 'next-auth'
 import GoogleProvider from 'next-auth/providers/google'
 
-const prisma = new PrismaClient()
+import { prisma } from '@/prisma/client'
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),

--- a/pages/api/graphql/resolver/index.ts
+++ b/pages/api/graphql/resolver/index.ts
@@ -1,8 +1,6 @@
-import { PrismaClient } from '@prisma/client'
-
 import { Resolvers } from '../types/graphql'
 
-const prisma = new PrismaClient()
+import { prisma } from '@/prisma/client'
 
 export const resolvers: Resolvers = {
   Query: {

--- a/prisma/client.ts
+++ b/prisma/client.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = global as unknown as {
+  prisma: PrismaClient | undefined
+}
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: ['query'],
+  })
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma


### PR DESCRIPTION
NextJSでPrisma Clientを使用していると次のようなWarningが発生した

```
warn(prisma-client) There are already 10 instances of Prisma Client actively running.
```
next devでホットリロードが実行されると、そのたびにPrisma Clientインスタンスが初期化されて、それぞれのインスタンスが接続を保持し続けることで発生する

# solution
[公式ドキュメント](https://www.prisma.io/docs/guides/other/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices)に従って、Prisma Clientをシングルトンにした
